### PR TITLE
chore: update Ubuntu version in workflow matrix from 20.04 to 24.04

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'push'
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         one_command: [true, false]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to ensure compatibility with the latest Ubuntu version.

* [`.github/workflows/testing.yaml`](diffhunk://#diff-cf3dd985ec02b2c727885d15dd9a5eca1e2f1ed708cb81406d99f57099aed253L35-R35): Updated the matrix of operating systems to replace `ubuntu-20.04` with `ubuntu-24.04`, reflecting a move to support newer environments while maintaining `ubuntu-22.04`.